### PR TITLE
Fix: Revert removal of `equals()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,11 +127,17 @@ use Ergebnis\Version;
 
 $one = Version\Version::fromString('1.2.3-alpha');
 $two = Version\Version::fromString('1.2.3');
-$three = Version\Version::fromString('1.2.4+build.9001');
+$three = Version\Version::fromString('1.2.4');
+$four = Version\Version::fromString('1.2.4+build.9001');
 
 $one->compare($two); // -1
 $one->compare($one); // 0
 $three->compare($one); // 1
+
+$one->equals($two); // false
+$one->equals($one); // true
+$one->equals($three); // false
+$three->equals($four); // true
 ```
 
 ### Create a `Major` from an `int`
@@ -193,6 +199,9 @@ $two = Version\Major::fromString('2');
 $one->compare($two); // -1
 $one->compare($one); // 0
 $two->compare($one); // 1
+
+$one->equals($two); // false
+$one->equals($one); // true
 ```
 
 ### Create a `Minor` from an `int`
@@ -254,6 +263,9 @@ $two = Version\Minor::fromString('2');
 $one->compare($two); // -1
 $one->compare($one); // 0
 $two->compare($one); // 1
+
+$one->equals($two); // false
+$one->equals($one); // true
 ```
 
 ### Create a `Patch` from an `int`
@@ -315,6 +327,9 @@ $two = Version\Patch::fromString('2');
 $one->compare($two); // -1
 $one->compare($one); // 0
 $two->compare($one); // 1
+
+$one->equals($two); // false
+$one->equals($one); // true
 ```
 
 ### Create a `PreRelease` from a `string`
@@ -360,6 +375,10 @@ $two = Version\PreRelease::fromString('rc.1');
 $one->compare($two); // -1
 $one->compare($one); // 0
 $two->compare($one); // 1
+
+$one->equals($two); // false
+$one->equals($one); // true
+
 ```
 
 ### Create a `BuildMetaData` from a `string`
@@ -400,13 +419,10 @@ declare(strict_types=1);
 use Ergebnis\Version;
 
 $one = Version\BuildMetaData::fromString('build.9001');
-$two = Version\BuildMetaData::fromString('build.9001');
-$three = Version\BuildMetaData::fromString('build.9000');
+$two = Version\BuildMetaData::fromString('build.9000');
 
-$one->equals($two); // true
-$one->equals($three); // false
-
-$one->equals($two); // true
+$one->equals($two); // false
+$one->equals($one); // true
 ```
 
 ## Changelog

--- a/src/Major.php
+++ b/src/Major.php
@@ -79,4 +79,9 @@ final class Major
     {
         return $this->value <=> $other->value;
     }
+
+    public function equals(self $other): bool
+    {
+        return $this->value === $other->value;
+    }
 }

--- a/src/Minor.php
+++ b/src/Minor.php
@@ -79,4 +79,9 @@ final class Minor
     {
         return $this->value <=> $other->value;
     }
+
+    public function equals(self $other): bool
+    {
+        return $this->value === $other->value;
+    }
 }

--- a/src/Patch.php
+++ b/src/Patch.php
@@ -79,4 +79,9 @@ final class Patch
     {
         return $this->value <=> $other->value;
     }
+
+    public function equals(self $other): bool
+    {
+        return $this->value === $other->value;
+    }
 }

--- a/src/Version.php
+++ b/src/Version.php
@@ -186,6 +186,11 @@ final class Version
         return 0;
     }
 
+    public function equals(self $other): bool
+    {
+        return 0 === $this->compare($other);
+    }
+
     public function major(): Major
     {
         return $this->major;

--- a/test/Unit/MajorTest.php
+++ b/test/Unit/MajorTest.php
@@ -179,4 +179,24 @@ final class MajorTest extends Framework\TestCase
 
         self::assertSame(1, $one->compare($two));
     }
+
+    public function testEqualsReturnsFalseWhenValuesAreDifferent(): void
+    {
+        $faker = self::faker()->unique();
+
+        $one = Major::fromInt($faker->numberBetween(0));
+        $two = Major::fromInt($faker->numberBetween(0));
+
+        self::assertFalse($one->equals($two));
+    }
+
+    public function testEqualsReturnsFalseWhenValuesAreSame(): void
+    {
+        $value = self::faker()->numberBetween(0);
+
+        $one = Major::fromInt($value);
+        $two = Major::fromInt($value);
+
+        self::assertTrue($one->equals($two));
+    }
 }

--- a/test/Unit/MinorTest.php
+++ b/test/Unit/MinorTest.php
@@ -179,4 +179,24 @@ final class MinorTest extends Framework\TestCase
 
         self::assertSame(1, $one->compare($two));
     }
+
+    public function testEqualsReturnsFalseWhenValuesAreDifferent(): void
+    {
+        $faker = self::faker()->unique();
+
+        $one = Minor::fromInt($faker->numberBetween(0));
+        $two = Minor::fromInt($faker->numberBetween(0));
+
+        self::assertFalse($one->equals($two));
+    }
+
+    public function testEqualsReturnsFalseWhenValuesAreSame(): void
+    {
+        $value = self::faker()->numberBetween(0);
+
+        $one = Minor::fromInt($value);
+        $two = Minor::fromInt($value);
+
+        self::assertTrue($one->equals($two));
+    }
 }

--- a/test/Unit/PatchTest.php
+++ b/test/Unit/PatchTest.php
@@ -179,4 +179,24 @@ final class PatchTest extends Framework\TestCase
 
         self::assertSame(1, $one->compare($two));
     }
+
+    public function testEqualsReturnsFalseWhenValuesAreDifferent(): void
+    {
+        $faker = self::faker()->unique();
+
+        $one = Patch::fromInt($faker->numberBetween(0));
+        $two = Patch::fromInt($faker->numberBetween(0));
+
+        self::assertFalse($one->equals($two));
+    }
+
+    public function testEqualsReturnsFalseWhenValuesAreSame(): void
+    {
+        $value = self::faker()->numberBetween(0);
+
+        $one = Patch::fromInt($value);
+        $two = Patch::fromInt($value);
+
+        self::assertTrue($one->equals($two));
+    }
 }

--- a/test/Unit/VersionTest.php
+++ b/test/Unit/VersionTest.php
@@ -388,4 +388,35 @@ final class VersionTest extends Framework\TestCase
 
         self::assertSame(1, $one->compare($two));
     }
+
+    #[Framework\Attributes\DataProviderExternal(Test\DataProvider\VersionProvider::class, 'valuesWhereFirstValueIsGreaterThanSecondValue')]
+    public function testEqualsReturnsFalseWhenValuesAreDifferent(
+        string $firstValue,
+        string $secondValue,
+    ): void {
+        $one = Version::fromString($firstValue);
+        $two = Version::fromString($secondValue);
+
+        self::assertFalse($one->equals($two));
+    }
+
+    #[Framework\Attributes\DataProviderExternal(Test\DataProvider\VersionProvider::class, 'valuesWhereFirstValueIsEqualToSecondValue')]
+    public function testEqualsReturnsTrueWhenValuesAreEqual(
+        string $firstValue,
+        string $secondValue,
+    ): void {
+        $one = Version::fromString($firstValue);
+        $two = Version::fromString($secondValue);
+
+        self::assertTrue($one->equals($two));
+    }
+
+    #[Framework\Attributes\DataProviderExternal(Test\DataProvider\VersionProvider::class, 'valid')]
+    public function testEqualsReturnsTrueWhenValuesAreIdentical(string $value): void
+    {
+        $one = Version::fromString($value);
+        $two = Version::fromString($value);
+
+        self::assertTrue($one->equals($two));
+    }
 }


### PR DESCRIPTION
This pull request

- [x] reverts the removal of `equals()`